### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE-MPL-rabbitmq-external-exchange
+++ b/LICENSE-MPL-rabbitmq-external-exchange
@@ -437,7 +437,7 @@ EXHIBIT A -Mozilla Public License.
      ``The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
      compliance with the License. You may obtain a copy of the License at
-     http://www.mozilla.org/MPL/
+     https://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on an "AS IS"
      basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/examples/erlang/include/rabbit_external_exchange_type_spec.hrl
+++ b/examples/erlang/include/rabbit_external_exchange_type_spec.hrl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/examples/erlang/src/rabbit_external_exchange_driver.erl
+++ b/examples/erlang/src/rabbit_external_exchange_driver.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/examples/erlang/src/rabbit_external_exchange_example.erl
+++ b/examples/erlang/src/rabbit_external_exchange_example.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/examples/erlang/src/rabbit_external_exchange_type.erl
+++ b/examples/erlang/src/rabbit_external_exchange_type.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/examples/java/src/com/rabbitmq/plugins/externalexchange/Binding.java
+++ b/examples/java/src/com/rabbitmq/plugins/externalexchange/Binding.java
@@ -1,7 +1,7 @@
 //  The contents of this file are subject to the Mozilla Public License
 //  Version 1.1 (the "License"); you may not use this file except in
 //  compliance with the License. You may obtain a copy of the License
-//  at http://www.mozilla.org/MPL/
+//  at https://www.mozilla.org/MPL/
 //
 //  Software distributed under the License is distributed on an "AS IS"
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/examples/java/src/com/rabbitmq/plugins/externalexchange/ExchangeType.java
+++ b/examples/java/src/com/rabbitmq/plugins/externalexchange/ExchangeType.java
@@ -1,7 +1,7 @@
 //  The contents of this file are subject to the Mozilla Public License
 //  Version 1.1 (the "License"); you may not use this file except in
 //  compliance with the License. You may obtain a copy of the License
-//  at http://www.mozilla.org/MPL/
+//  at https://www.mozilla.org/MPL/
 //
 //  Software distributed under the License is distributed on an "AS IS"
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/examples/java/src/com/rabbitmq/plugins/externalexchange/example/ExampleExchangeType.java
+++ b/examples/java/src/com/rabbitmq/plugins/externalexchange/example/ExampleExchangeType.java
@@ -1,7 +1,7 @@
 //  The contents of this file are subject to the Mozilla Public License
 //  Version 1.1 (the "License"); you may not use this file except in
 //  compliance with the License. You may obtain a copy of the License
-//  at http://www.mozilla.org/MPL/
+//  at https://www.mozilla.org/MPL/
 //
 //  Software distributed under the License is distributed on an "AS IS"
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/examples/java/src/com/rabbitmq/plugins/externalexchange/impl/BindingImpl.java
+++ b/examples/java/src/com/rabbitmq/plugins/externalexchange/impl/BindingImpl.java
@@ -1,7 +1,7 @@
 //  The contents of this file are subject to the Mozilla Public License
 //  Version 1.1 (the "License"); you may not use this file except in
 //  compliance with the License. You may obtain a copy of the License
-//  at http://www.mozilla.org/MPL/
+//  at https://www.mozilla.org/MPL/
 //
 //  Software distributed under the License is distributed on an "AS IS"
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/examples/java/src/com/rabbitmq/plugins/externalexchange/impl/ExchangeTypeImpl.java
+++ b/examples/java/src/com/rabbitmq/plugins/externalexchange/impl/ExchangeTypeImpl.java
@@ -1,7 +1,7 @@
 //  The contents of this file are subject to the Mozilla Public License
 //  Version 1.1 (the "License"); you may not use this file except in
 //  compliance with the License. You may obtain a copy of the License
-//  at http://www.mozilla.org/MPL/
+//  at https://www.mozilla.org/MPL/
 //
 //  Software distributed under the License is distributed on an "AS IS"
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/rabbit_external_exchange.erl
+++ b/src/rabbit_external_exchange.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.mozilla.org/MPL/ with 11 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).